### PR TITLE
feat(Token): support per-call secret override in generate/isValid/validateUnique

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ run-tests.log
 /test/*/*/*/*.log
 /test/*/*/*/*.out
 
+/var
+/web
+
 # Composer dependencies
 /vendor/
 composer.lock

--- a/src/Token.php
+++ b/src/Token.php
@@ -138,24 +138,40 @@ final class Token
     /**
      * Generate a new CSRF token
      *
-     * @param string $seed Optional seed for context binding
+     * Pass a per-call $secret to sign with a different key without
+     * rebuilding the Token service. This is the preferred way to handle
+     * multiple secrets within one request (e.g., a service iterating
+     * sessions or composing tokens for several identities). Constructing
+     * a new Token per secret is feasible but wasteful — storage and
+     * config are invariant across calls.
+     *
+     * @param string      $seed   Optional seed for context binding
+     * @param string|null $secret Per-call secret override; null uses the
+     *                            configured secret.
      * @return GeneratedToken The generated token
      *
      * @example
      * $token = $service->generate('checkout_form');
      * echo $token->token;  // Use in form
+     *
+     * @example
+     * // Per-call secret without rebuilding the Token service
+     * $token = $service->generate('checkout_form', $session->getSecret());
      */
-    public function generate(string $seed = ''): GeneratedToken
+    public function generate(string $seed = '', ?string $secret = null): GeneratedToken
     {
-        return $this->generator->generate($seed);
+        return $this->generator->generate($seed, $secret);
     }
 
     /**
      * Check if token is valid (non-throwing version)
      *
-     * @param string $token The token to validate
-     * @param string $seed The seed used during generation
-     * @param int|null $timeout Custom timeout (null = use config)
+     * @param string      $token   The token to validate
+     * @param string      $seed    The seed used during generation
+     * @param int|null    $timeout Custom timeout (null = use config)
+     * @param string|null $secret  Per-call secret override; null uses the
+     *                             configured secret. See {@see generate()}
+     *                             for the rationale.
      * @return bool True if token is valid
      *
      * @example
@@ -166,16 +182,20 @@ final class Token
     public function isValid(
         string $token,
         string $seed = '',
-        ?int $timeout = null
+        ?int $timeout = null,
+        ?string $secret = null
     ): bool {
-        return $this->validator->isValid($token, $seed, $timeout);
+        return $this->validator->isValid($token, $seed, $timeout, $secret);
     }
 
     /**
      * Validate token and mark as used (one-time use)
      *
-     * @param string $token The token to validate
-     * @param string $seed The seed used during generation
+     * @param string      $token  The token to validate
+     * @param string      $seed   The seed used during generation
+     * @param string|null $secret Per-call secret override; null uses the
+     *                            configured secret. See {@see generate()}
+     *                            for the rationale.
      * @return void
      * @throws Exception\InvalidTokenException If signature is invalid
      * @throws Exception\ExpiredTokenException If token has expired
@@ -189,9 +209,9 @@ final class Token
      *     // Token invalid
      * }
      */
-    public function validateUnique(string $token, string $seed = ''): void
+    public function validateUnique(string $token, string $seed = '', ?string $secret = null): void
     {
-        $this->validator->validateUnique($token, $seed);
+        $this->validator->validateUnique($token, $seed, $secret);
     }
 
     /**

--- a/src/TokenGenerator.php
+++ b/src/TokenGenerator.php
@@ -47,25 +47,43 @@ final class TokenGenerator
     /**
      * Generate a new CSRF token
      *
-     * The token is signed with HMAC-SHA256 using the configured secret.
-     * An optional seed can be included to bind the token to a specific
-     * context (e.g., form name, user action).
+     * The token is signed with HMAC-SHA256 using the configured secret
+     * (or the per-call override, if supplied). An optional seed can be
+     * included to bind the token to a specific context (e.g., form name,
+     * user action).
      *
-     * @param string $seed Optional seed for context binding
+     * Pass a per-call $secret to sign with a different key without
+     * constructing a new TokenGenerator. This is the preferred way for
+     * services that process multiple secrets in a single request (for
+     * example, iterating sessions in an admin tool, or composing tokens
+     * for multiple identities). Constructing many TokenGenerator
+     * instances is feasible but wasteful — the rest of the configuration
+     * is invariant across calls.
+     *
+     * @param string      $seed   Optional seed for context binding
+     * @param string|null $secret Per-call secret override; null uses the
+     *                            configured secret (default behaviour).
      * @return GeneratedToken The generated token with expiry information
      *
      * @example
      * $generator = new TokenGenerator($config);
      * $token = $generator->generate('checkout_form');
      * echo $token->token;  // "base64url_encoded_token_string"
+     *
+     * @example
+     * // Per-call secret for session-bound token without rebuilding the generator
+     * $token = $generator->generate('checkout_form', $session->getSecret());
      */
-    public function generate(string $seed = ''): GeneratedToken
+    public function generate(string $seed = '', ?string $secret = null): GeneratedToken
     {
         // Generate nonce (timestamp + random data)
         $nonce = Nonce::generate();
 
         // Create signature: HMAC-SHA256(nonce + seed, secret)
-        $signature = Signer::sign($nonce->bytes() . $seed, $this->config->secret);
+        $signature = Signer::sign(
+            $nonce->bytes() . $seed,
+            $secret ?? $this->config->secret
+        );
 
         // Encode: Base64URL(nonce + signature)
         $token = Encoder::encode($nonce->bytes() . $signature);

--- a/src/TokenValidator.php
+++ b/src/TokenValidator.php
@@ -56,23 +56,37 @@ final class TokenValidator
      * Validates the token signature and expiration but does NOT
      * check for replay attacks or mark the token as used.
      *
-     * @param string $token The token to validate
-     * @param string $seed The seed used during generation
-     * @param int|null $timeout Custom timeout in seconds (null = use config)
+     * Pass a per-call $secret to verify with a different key without
+     * constructing a new TokenValidator. This is the preferred way for
+     * services that process multiple secrets in a single request — see
+     * {@see TokenGenerator::generate()} for the matching note.
+     *
+     * @param string      $token   The token to validate
+     * @param string      $seed    The seed used during generation
+     * @param int|null    $timeout Custom timeout in seconds (null = use config)
+     * @param string|null $secret  Per-call secret override; null uses the
+     *                             configured secret (default behaviour).
      * @return bool True if token is valid
      *
      * @example
      * if ($validator->isValid($token, 'form_id')) {
      *     // Token is valid
      * }
+     *
+     * @example
+     * // Per-call secret for session-bound verification without rebuilding
+     * if ($validator->isValid($token, 'form_id', null, $session->getSecret())) {
+     *     // ...
+     * }
      */
     public function isValid(
         string $token,
         string $seed = '',
-        ?int $timeout = null
+        ?int $timeout = null,
+        ?string $secret = null
     ): bool {
         try {
-            $this->validateInternal($token, $seed, $timeout, unique: false);
+            $this->validateInternal($token, $seed, $timeout, unique: false, secret: $secret);
             return true;
         } catch (InvalidTokenException|ExpiredTokenException) {
             return false;
@@ -87,8 +101,10 @@ final class TokenValidator
      * 2. Checks if token was previously used
      * 3. Marks token as used to prevent replay attacks
      *
-     * @param string $token The token to validate
-     * @param string $seed The seed used during generation
+     * @param string      $token  The token to validate
+     * @param string      $seed   The seed used during generation
+     * @param string|null $secret Per-call secret override; null uses the
+     *                            configured secret (default behaviour).
      * @return void
      * @throws InvalidTokenException If signature is invalid
      * @throws ExpiredTokenException If token has expired
@@ -102,18 +118,20 @@ final class TokenValidator
      *     // Token already used (replay attack)
      * }
      */
-    public function validateUnique(string $token, string $seed = ''): void
+    public function validateUnique(string $token, string $seed = '', ?string $secret = null): void
     {
-        $this->validateInternal($token, $seed, timeout: null, unique: true);
+        $this->validateInternal($token, $seed, timeout: null, unique: true, secret: $secret);
     }
 
     /**
      * Internal validation logic
      *
-     * @param string $token The token to validate
-     * @param string $seed The seed used during generation
-     * @param int|null $timeout Custom timeout (null = use config)
-     * @param bool $unique Whether to check for replay and mark as used
+     * @param string      $token   The token to validate
+     * @param string      $seed    The seed used during generation
+     * @param int|null    $timeout Custom timeout (null = use config)
+     * @param bool        $unique  Whether to check for replay and mark as used
+     * @param string|null $secret  Per-call secret override; null uses the
+     *                             configured secret.
      * @return void
      * @throws InvalidTokenException If signature is invalid or token is malformed
      * @throws ExpiredTokenException If token has expired
@@ -123,7 +141,8 @@ final class TokenValidator
         string $token,
         string $seed,
         ?int $timeout,
-        bool $unique
+        bool $unique,
+        ?string $secret = null
     ): void {
         // Decode token from Base64 URL format
         try {
@@ -142,7 +161,10 @@ final class TokenValidator
         $signature = substr($decoded, 6);
 
         // Verify signature
-        $expectedSignature = Signer::sign($nonceBytes . $seed, $this->config->secret);
+        $expectedSignature = Signer::sign(
+            $nonceBytes . $seed,
+            $secret ?? $this->config->secret
+        );
         if (!hash_equals($expectedSignature, $signature)) {
             throw new InvalidTokenException('Invalid token signature');
         }

--- a/test/Unit/TokenGeneratorTest.php
+++ b/test/Unit/TokenGeneratorTest.php
@@ -123,4 +123,33 @@ class TokenGeneratorTest extends TestCase
 
         $this->assertEquals($token->token, $tokenString);
     }
+
+    public function testGenerateWithPerCallSecretProducesDifferentTokenThanConstructorSecret(): void
+    {
+        $config = TokenConfig::default('constructor-secret');
+        $generator = new TokenGenerator($config);
+
+        // Identical seed and (essentially) identical timestamp; the only
+        // difference is the secret used to sign. Outputs must differ.
+        $tokenA = $generator->generate('same-seed', 'override-secret');
+        $tokenB = $generator->generate('same-seed', 'constructor-secret');
+
+        $this->assertNotEquals($tokenA->token, $tokenB->token);
+    }
+
+    public function testGenerateWithoutSecretFallsBackToConstructorSecret(): void
+    {
+        $config = TokenConfig::default('constructor-secret');
+        $generator = new TokenGenerator($config);
+
+        $tokenDefault = $generator->generate('seed');
+        $tokenExplicit = $generator->generate('seed', 'constructor-secret');
+
+        // They use the same secret but DIFFER in nonce timestamp/random,
+        // so we cannot compare bytes; instead, both must validate against
+        // the same secret (covered by TokenValidatorTest::testValidateWith*).
+        // Smoke check: both produce 51-char base64url output.
+        $this->assertSame(51, strlen($tokenDefault->token));
+        $this->assertSame(51, strlen($tokenExplicit->token));
+    }
 }

--- a/test/Unit/TokenTest.php
+++ b/test/Unit/TokenTest.php
@@ -229,4 +229,31 @@ class TokenTest extends TestCase
         $token->validateUnique($generated->token);
         $this->assertTrue(true); // Assert we got here
     }
+
+    public function testGenerateAndIsValidWithPerCallSecretRoundTrip(): void
+    {
+        $token = Token::null('constructor-secret');
+
+        // Sign with override; verify with same override; must validate.
+        $generated = $token->generate('seed', 'override-secret');
+        $this->assertTrue(
+            $token->isValid($generated->token, 'seed', null, 'override-secret')
+        );
+
+        // Verify with constructor secret; must reject.
+        $this->assertFalse(
+            $token->isValid($generated->token, 'seed')
+        );
+    }
+
+    public function testValidateUniqueWithPerCallSecretRoundTrip(): void
+    {
+        $token = Token::null('constructor-secret');
+
+        $generated = $token->generate('seed', 'override-secret');
+
+        // Same override must validate without throwing
+        $token->validateUnique($generated->token, 'seed', 'override-secret');
+        $this->assertTrue(true);
+    }
 }

--- a/test/Unit/TokenValidatorTest.php
+++ b/test/Unit/TokenValidatorTest.php
@@ -183,4 +183,67 @@ class TokenValidatorTest extends TestCase
         // Old tokens should be purged, only new token remains
         $this->assertEquals(1, $storage->count());
     }
+
+    public function testIsValidAcceptsTokenSignedWithPerCallSecret(): void
+    {
+        $config = TokenConfig::default('constructor-secret');
+        $storage = new InMemoryStorage();
+        $generator = new TokenGenerator($config);
+        $validator = new TokenValidator($config, $storage);
+
+        $token = $generator->generate('seed', 'override-secret');
+
+        // Verifier must use the same per-call secret to validate
+        $this->assertTrue(
+            $validator->isValid($token->token, 'seed', null, 'override-secret')
+        );
+    }
+
+    public function testIsValidRejectsPerCallSignedTokenWhenSecretMismatches(): void
+    {
+        $config = TokenConfig::default('constructor-secret');
+        $storage = new InMemoryStorage();
+        $generator = new TokenGenerator($config);
+        $validator = new TokenValidator($config, $storage);
+
+        $token = $generator->generate('seed', 'secret-A');
+
+        // Wrong secret on verify side: must reject
+        $this->assertFalse(
+            $validator->isValid($token->token, 'seed', null, 'secret-B')
+        );
+
+        // Constructor secret on verify side: must also reject
+        $this->assertFalse(
+            $validator->isValid($token->token, 'seed', null, null)
+        );
+    }
+
+    public function testValidateUniqueAcceptsTokenSignedWithPerCallSecret(): void
+    {
+        $config = TokenConfig::default('constructor-secret');
+        $storage = new InMemoryStorage();
+        $generator = new TokenGenerator($config);
+        $validator = new TokenValidator($config, $storage);
+
+        $token = $generator->generate('seed', 'override-secret');
+
+        // Should not throw
+        $validator->validateUnique($token->token, 'seed', 'override-secret');
+
+        $this->assertTrue($storage->exists($token->token));
+    }
+
+    public function testValidateUniqueRejectsTokenWithMismatchedPerCallSecret(): void
+    {
+        $config = TokenConfig::default('constructor-secret');
+        $storage = new InMemoryStorage();
+        $generator = new TokenGenerator($config);
+        $validator = new TokenValidator($config, $storage);
+
+        $token = $generator->generate('seed', 'secret-A');
+
+        $this->expectException(InvalidTokenException::class);
+        $validator->validateUnique($token->token, 'seed', 'secret-B');
+    }
 }


### PR DESCRIPTION
Extends `Horde\Token\Token::generate()`, `Token::isValid()`, and `Token::validateUnique()` (plus the underlying `TokenGenerator::generate()` and `TokenValidator::validate()`) with an optional trailing `?string $secret = null` parameter. When omitted, the constructor's secret is used (existing behavior preserved). When supplied, that single call signs/verifies with the override.

Rationale: services that handle multiple secrets per request (iterating sessions, composing tokens for several identities) can now share one Token instance instead of constructing many.

8 new unit tests cover the override paths; all 58 pre-existing tests pass unchanged.

Refs https://github.com/horde/Token/issues/3